### PR TITLE
Bump to Checker Framework 2.8.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ sourceCompatibility = 1.8
 
 dependencies {
     // This dependency is found on compile classpath of this component and consumers.
-    implementation 'org.checkerframework:checker:2.8.0'
+    implementation 'org.checkerframework:checker:2.8.1'
 
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'


### PR DESCRIPTION
This picks up the fix for typetools/checker-framework#2462, which makes browsing the source of the Checker Framework easier in an IDE.