### PR TITLE
Implementation of @CalledMethodsPredicate

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,8 +15,13 @@ dependencies {
     // This dependency is found on compile classpath of this component and consumers.
     implementation 'org.checkerframework:checker:2.8.1'
 
+    // For the @CalledMethodsPredicate evaluation
+    implementation 'com.fathzer:javaluator:3.0.2'
+    
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'
+    
+    // CF testing infrastructure
     testCompile 'org.checkerframework:testlib:2.5.4'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,9 @@
 plugins {
     // Apply the java plugin to add support for Java
     id 'java'
+
+    // For bringing in AWS dependencies
+    id 'io.spring.dependency-management' version '1.0.7.RELEASE'
 }
 
 repositories {
@@ -17,12 +20,21 @@ dependencies {
 
     // For the @CalledMethodsPredicate evaluation
     implementation 'com.fathzer:javaluator:3.0.2'
-    
+
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'
-    
+
     // CF testing infrastructure
     testCompile 'org.checkerframework:testlib:2.5.4'
+
+    // For CVE tests
+    testCompile 'com.amazonaws:aws-java-sdk-ec2'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom 'com.amazonaws:aws-java-sdk-bom:1.11.228'
+    }
 }
 
 tasks.withType(JavaCompile).all {

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,10 @@ plugins {
     // Apply the java plugin to add support for Java
     id 'java'
 
-    // For bringing in AWS dependencies
+    // For bringing in AWS dependencies. We're using the "legacy" version
+    // listed here: https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/setup-project-gradle.html,
+    // because the build fails when we use the Gradle 5+ way, saying that it can't find ec2.
+    // I believe that this is because we need the AWS SDK during testing, but not during the build.
     id 'io.spring.dependency-management' version '1.0.7.RELEASE'
 
     id 'maven-publish'

--- a/src/main/java/org/checkerframework/checker/builder/CalledMethodsPredicateEvaluator.java
+++ b/src/main/java/org/checkerframework/checker/builder/CalledMethodsPredicateEvaluator.java
@@ -1,0 +1,75 @@
+package org.checkerframework.checker.builder;
+
+import com.fathzer.soft.javaluator.AbstractEvaluator;
+import com.fathzer.soft.javaluator.BracketPair;
+import com.fathzer.soft.javaluator.Operator;
+import com.fathzer.soft.javaluator.Parameters;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * This class parses and evaluates a single @CalledMethodsPredicate argument.
+ * It is based on an answer to this StackOverflow question:
+ * https://stackoverflow.com/questions/12203003/boolean-expression-parser-in-java
+ */
+public class CalledMethodsPredicateEvaluator extends AbstractEvaluator<String> {
+    /**
+     * The logical AND operator.
+     */
+    final static Operator AND = new Operator("&&", 2, Operator.Associativity.LEFT, 2);
+    /**
+     * The logical OR operator.
+     */
+    final static Operator OR = new Operator("||", 2, Operator.Associativity.LEFT, 1);
+
+    private static final Parameters PARAMETERS;
+
+    // A set containing all the names of methods that ought to evaluate to true.
+    private final Set<String> cmMethods;
+
+    static {
+        // Create the evaluator's parameters
+        PARAMETERS = new Parameters();
+        // Add the supported operators
+        PARAMETERS.add(AND);
+        PARAMETERS.add(OR);
+        // Add the parentheses
+        PARAMETERS.addExpressionBracket(BracketPair.PARENTHESES);
+    }
+
+    public CalledMethodsPredicateEvaluator(Set<String> cmMethods) {
+        super(PARAMETERS);
+        this.cmMethods = cmMethods;
+    }
+
+    @Override
+    protected String toValue(String literal, Object evaluationContext) {
+        return literal;
+    }
+
+    private boolean getValue(String literal) {
+        return cmMethods.contains(literal) || literal.endsWith("=true");
+    }
+
+    @Override
+    protected String evaluate(Operator operator, Iterator<String> operands,
+                              Object evaluationContext) {
+        @SuppressWarnings("unchecked") // for this evaluator, evaluationContext will always be a list of strings
+        List<String> tree = (List<String>) evaluationContext;
+        String o1 = operands.next();
+        String o2 = operands.next();
+        Boolean result;
+        if (operator == OR) {
+            result = getValue(o1) || getValue(o2);
+        } else if (operator == AND) {
+            result = getValue(o1) && getValue(o2);
+        } else {
+            throw new IllegalArgumentException();
+        }
+        String eval = "(" + o1 + " " + operator.getSymbol() + " " + o2 + ")=" + result;
+        tree.add(eval);
+        return eval;
+    }
+}

--- a/src/main/java/org/checkerframework/checker/builder/CalledMethodsPredicateEvaluator.java
+++ b/src/main/java/org/checkerframework/checker/builder/CalledMethodsPredicateEvaluator.java
@@ -6,7 +6,6 @@ import com.fathzer.soft.javaluator.Operator;
 import com.fathzer.soft.javaluator.Parameters;
 
 import java.util.Iterator;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -18,11 +17,13 @@ public class CalledMethodsPredicateEvaluator extends AbstractEvaluator<String> {
     /**
      * The logical AND operator.
      */
-    final static Operator AND = new Operator("&&", 2, Operator.Associativity.LEFT, 2);
+    private final static Operator AND =
+            new Operator("&&", 2, Operator.Associativity.LEFT, 2);
     /**
      * The logical OR operator.
      */
-    final static Operator OR = new Operator("||", 2, Operator.Associativity.LEFT, 1);
+    private final static Operator OR =
+            new Operator("||", 2, Operator.Associativity.LEFT, 1);
 
     private static final Parameters PARAMETERS;
 
@@ -39,23 +40,23 @@ public class CalledMethodsPredicateEvaluator extends AbstractEvaluator<String> {
         PARAMETERS.addExpressionBracket(BracketPair.PARENTHESES);
     }
 
-    public CalledMethodsPredicateEvaluator(Set<String> cmMethods) {
+    public CalledMethodsPredicateEvaluator(final Set<String> cmMethods) {
         super(PARAMETERS);
         this.cmMethods = cmMethods;
     }
 
     @Override
-    protected String toValue(String literal, Object evaluationContext) {
+    protected String toValue(final String literal, final Object evaluationContext) {
         return literal;
     }
 
-    private boolean getValue(String literal) {
+    private boolean getValue(final String literal) {
         return cmMethods.contains(literal) || "true".equals(literal);
     }
 
     @Override
-    protected String evaluate(Operator operator, Iterator<String> operands,
-                              Object evaluationContext) {
+    protected String evaluate(final Operator operator, final Iterator<String> operands,
+                              final Object evaluationContext) {
         String o1 = operands.next();
         String o2 = operands.next();
         Boolean result;

--- a/src/main/java/org/checkerframework/checker/builder/CalledMethodsPredicateEvaluator.java
+++ b/src/main/java/org/checkerframework/checker/builder/CalledMethodsPredicateEvaluator.java
@@ -50,14 +50,12 @@ public class CalledMethodsPredicateEvaluator extends AbstractEvaluator<String> {
     }
 
     private boolean getValue(String literal) {
-        return cmMethods.contains(literal) || literal.endsWith("=true");
+        return cmMethods.contains(literal) || "true".equals(literal);
     }
 
     @Override
     protected String evaluate(Operator operator, Iterator<String> operands,
                               Object evaluationContext) {
-        @SuppressWarnings("unchecked") // for this evaluator, evaluationContext will always be a list of strings
-        List<String> tree = (List<String>) evaluationContext;
         String o1 = operands.next();
         String o2 = operands.next();
         Boolean result;
@@ -68,8 +66,6 @@ public class CalledMethodsPredicateEvaluator extends AbstractEvaluator<String> {
         } else {
             throw new IllegalArgumentException();
         }
-        String eval = "(" + o1 + " " + operator.getSymbol() + " " + o2 + ")=" + result;
-        tree.add(eval);
-        return eval;
+        return result.toString();
     }
 }

--- a/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderAnnotatedTypeFactory.java
+++ b/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderAnnotatedTypeFactory.java
@@ -201,8 +201,7 @@ public class TypesafeBuilderAnnotatedTypeFactory extends BaseAnnotatedTypeFactor
                 // superAnno is a CMP annotation, so we need to evaluate the predicate
                 String predicate = AnnotationUtils.getElementValue(superAnno, "value", String.class, false);
                 CalledMethodsPredicateEvaluator evaluator = new CalledMethodsPredicateEvaluator(subVal);
-                String evalTree = evaluator.evaluate(predicate, new ArrayList<String>());
-                String result = evalTree.substring(evalTree.lastIndexOf('=') + 1);
+                String result = evaluator.evaluate(predicate);
                 return Boolean.parseBoolean(result);
             } else {
                 // superAnno is a CM annotation, so compare the sets

--- a/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderAnnotatedTypeFactory.java
+++ b/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderAnnotatedTypeFactory.java
@@ -21,7 +21,6 @@ import org.checkerframework.javacutil.TreeUtils;
 
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -76,12 +75,12 @@ public class TypesafeBuilderAnnotatedTypeFactory extends BaseAnnotatedTypeFactor
      * that have @ReturnsReceiver annotations.
      */
     private class TypesafeBuilderTreeAnnotator extends TreeAnnotator {
-        public TypesafeBuilderTreeAnnotator(AnnotatedTypeFactory atypeFactory) {
+        public TypesafeBuilderTreeAnnotator(final AnnotatedTypeFactory atypeFactory) {
             super(atypeFactory);
         }
 
         @Override
-        public Void visitMethodInvocation(MethodInvocationTree tree, AnnotatedTypeMirror type) {
+        public Void visitMethodInvocation(final MethodInvocationTree tree, final AnnotatedTypeMirror type) {
 
             // Check to see if the @ReturnsReceiver annotation is present
             Element element = TreeUtils.elementFromUse(tree);

--- a/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderAnnotatedTypeFactory.java
+++ b/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderAnnotatedTypeFactory.java
@@ -205,8 +205,7 @@ public class TypesafeBuilderAnnotatedTypeFactory extends BaseAnnotatedTypeFactor
                 return Boolean.parseBoolean(result);
             } else {
                 // superAnno is a CM annotation, so compare the sets
-                Set<String> superVal = new LinkedHashSet<>(getValueOfAnnotationWithStringArgument(superAnno));
-                return subVal.containsAll(superVal);
+                return subVal.containsAll(getValueOfAnnotationWithStringArgument(superAnno));
             }
         }
     }

--- a/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderVisitor.java
+++ b/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderVisitor.java
@@ -1,0 +1,42 @@
+package org.checkerframework.checker.builder;
+
+import com.sun.source.tree.AnnotationTree;
+import org.checkerframework.checker.builder.qual.CalledMethodsPredicate;
+import org.checkerframework.common.basetype.BaseTypeChecker;
+import org.checkerframework.common.basetype.BaseTypeVisitor;
+import org.checkerframework.framework.source.Result;
+import org.checkerframework.javacutil.AnnotationUtils;
+import org.checkerframework.javacutil.TreeUtils;
+
+import javax.lang.model.element.AnnotationMirror;
+import java.util.ArrayList;
+import java.util.Collections;
+
+public class TypesafeBuilderVisitor extends BaseTypeVisitor<TypesafeBuilderAnnotatedTypeFactory> {
+    /**
+     * @param checker the type-checker associated with this visitor
+     */
+    public TypesafeBuilderVisitor(BaseTypeChecker checker) {
+        super(checker);
+    }
+
+    /**
+     * Checks each @CalledMethodsPredicate annotation to make sure the predicate is well-formed.
+     */
+    @Override
+    public Void visitAnnotation(AnnotationTree node, Void p) {
+        AnnotationMirror anno = TreeUtils.annotationFromAnnotationTree(node);
+        if (AnnotationUtils.areSameByClass(anno, CalledMethodsPredicate.class)) {
+            String predicate =
+                    AnnotationUtils.getElementValue(anno, "value", String.class, false);
+
+            try {
+                new CalledMethodsPredicateEvaluator(Collections.emptySet()).evaluate(predicate, new ArrayList<>());
+            } catch (IllegalArgumentException e) {
+                checker.report(Result.failure("predicate.invalid", e.getMessage()), node);
+                return null;
+            }
+        }
+        return super.visitAnnotation(node, p);
+    }
+}

--- a/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderVisitor.java
+++ b/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderVisitor.java
@@ -16,7 +16,7 @@ public class TypesafeBuilderVisitor extends BaseTypeVisitor<TypesafeBuilderAnnot
     /**
      * @param checker the type-checker associated with this visitor
      */
-    public TypesafeBuilderVisitor(BaseTypeChecker checker) {
+    public TypesafeBuilderVisitor(final BaseTypeChecker checker) {
         super(checker);
     }
 
@@ -24,7 +24,7 @@ public class TypesafeBuilderVisitor extends BaseTypeVisitor<TypesafeBuilderAnnot
      * Checks each @CalledMethodsPredicate annotation to make sure the predicate is well-formed.
      */
     @Override
-    public Void visitAnnotation(AnnotationTree node, Void p) {
+    public Void visitAnnotation(final AnnotationTree node, final Void p) {
         AnnotationMirror anno = TreeUtils.annotationFromAnnotationTree(node);
         if (AnnotationUtils.areSameByClass(anno, CalledMethodsPredicate.class)) {
             String predicate =

--- a/src/main/java/org/checkerframework/checker/builder/messages.properties
+++ b/src/main/java/org/checkerframework/checker/builder/messages.properties
@@ -1,0 +1,1 @@
+An unparseable predicate was found in an annotation. Predicates must be produced by this grammar: S → method name | (S) | S && S | S || S. The message from the evaluator was: %s \n

--- a/src/main/java/org/checkerframework/checker/builder/qual/CalledMethods.java
+++ b/src/main/java/org/checkerframework/checker/builder/qual/CalledMethods.java
@@ -1,6 +1,5 @@
 package org.checkerframework.checker.builder.qual;
 
-import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.SubtypeOf;
 
 import java.lang.annotation.ElementType;
@@ -17,8 +16,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
-@SubtypeOf({})
-@DefaultQualifierInHierarchy
+@SubtypeOf({CalledMethodsTop.class})
 public @interface CalledMethods {
     /** A list of methods that have been called on the annotated object. */
     public String[] value() default {};

--- a/src/main/java/org/checkerframework/checker/builder/qual/CalledMethodsBottom.java
+++ b/src/main/java/org/checkerframework/checker/builder/qual/CalledMethodsBottom.java
@@ -18,7 +18,7 @@ import java.lang.annotation.Target;
  * It should rarely, if ever, be written by a programmer.
  */
 
-@SubtypeOf(CalledMethods.class)
+@SubtypeOf({CalledMethods.class, CalledMethodsPredicate.class})
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})

--- a/src/main/java/org/checkerframework/checker/builder/qual/CalledMethodsPredicate.java
+++ b/src/main/java/org/checkerframework/checker/builder/qual/CalledMethodsPredicate.java
@@ -1,0 +1,34 @@
+package org.checkerframework.checker.builder.qual;
+
+import org.checkerframework.framework.qual.SubtypeOf;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation represents a predicate on @CalledMethods
+ * annotations that must be true. It is intended to extend
+ * the possible LUB of the @CalledMethods type system to
+ * permit methods to be annotated to require a disjunction
+ * of method calls. So, for instance, if it was acceptable
+ * to call method a() or method b() before calling method c(),
+ * then c()'s receiver should have an @CalledMethodsPredicate
+ * annotation with the argument "a || b"
+ *
+ * The argument is a string. The string must be constructed
+ * from the following grammar:
+ *
+ * S → method name | (S) | S && S | S || S
+ *
+ * That is, the permitted elements are method names, parentheses,
+ * and the strings "&&" and "||". "&&" has higher precedence
+ * than "||", following standard Java operator semantics.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({CalledMethodsTop.class})
+public @interface CalledMethodsPredicate {
+    String value();
+}

--- a/src/main/java/org/checkerframework/checker/builder/qual/CalledMethodsTop.java
+++ b/src/main/java/org/checkerframework/checker/builder/qual/CalledMethodsTop.java
@@ -1,0 +1,21 @@
+package org.checkerframework.checker.builder.qual;
+
+import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
+import org.checkerframework.framework.qual.SubtypeOf;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The default qualifier in the hierarchy. It is equivalent to @CalledMethods({}).
+ *
+ * Needed so that @CalledMethodsPredicate can be a sibling of @CalledMethods.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@DefaultQualifierInHierarchy
+@SubtypeOf({})
+public @interface CalledMethodsTop {
+}

--- a/src/test/java/tests/EC2Test.java
+++ b/src/test/java/tests/EC2Test.java
@@ -1,0 +1,23 @@
+package tests;
+
+import org.checkerframework.framework.test.CheckerFrameworkPerDirectoryTest;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.util.List;
+
+public class EC2Test extends CheckerFrameworkPerDirectoryTest {
+    public EC2Test(List<File> testFiles) {
+        super(testFiles,
+                org.checkerframework.checker.builder.TypesafeBuilderChecker.class,
+                "cve",
+                "-Anomsgtext",
+                "-Astubs=stubs",
+                "-nowarn");
+    }
+
+    @Parameterized.Parameters
+    public static String[] getTestDirs() {
+        return new String[] {"cve"};
+    }
+}

--- a/stubs/DescribeImages.astub
+++ b/stubs/DescribeImages.astub
@@ -1,10 +1,24 @@
 package com.amazonaws.services.ec2;
 
-import org.checkerframework.checker.builder.qual.CalledMethodsPredicate;
+import org.checkerframework.checker.builder.qual.*;
 
 class AmazonEC2 {
     DescribeImagesResult describeImages(
     // any combination of withX/setX has to be permitted if both a filter and an owner has been set or an imageId has been set
-    @CalledMethodsPredicate("((withFilters OR setFilters) AND (withOwners OR setOwners)) OR (withImageIds OR setImageIds)")
+    @CalledMethodsPredicate("((withFilters || setFilters) && (withOwners || setOwners)) || (withImageIds || setImageIds)")
     DescribeImagesRequest request);
+}
+
+package com.amazonaws.services.ec2.model;
+
+class DescribeImagesRequest {
+
+    @ReturnsReceiver
+    DescribeImagesRequest withFilters(Filter... f);
+
+    @ReturnsReceiver
+    DescribeImagesRequest withOwners(String... o);
+
+    @ReturnsReceiver
+    DescribeImagesRequest withImageIds(String... i);
 }

--- a/stubs/DescribeImages.astub
+++ b/stubs/DescribeImages.astub
@@ -1,0 +1,10 @@
+package com.amazonaws.services.ec2;
+
+import org.checkerframework.checker.builder.qual.CalledMethodsPredicate;
+
+class AmazonEC2 {
+    DescribeImagesResult describeImages(
+    // any combination of withX/setX has to be permitted if both a filter and an owner has been set or an imageId has been set
+    @CalledMethodsPredicate("((withFilters OR setFilters) AND (withOwners OR setOwners)) OR (withImageIds OR setImageIds)")
+    DescribeImagesRequest request);
+}

--- a/tests/basic/CmPredicate.java
+++ b/tests/basic/CmPredicate.java
@@ -1,0 +1,170 @@
+import org.checkerframework.checker.builder.qual.*;
+
+class CmPredicate {
+
+    void testOr1() {
+        MyClass m1 = new MyClass();
+
+        // :: error: method.invocation.invalid
+        m1.c();
+    }
+
+    void testOr2() {
+        MyClass m1 = new MyClass();
+
+        m1.a();
+        m1.c();
+    }
+
+    void testOr3() {
+        MyClass m1 = new MyClass();
+
+        m1.b();
+        m1.c();
+    }
+
+    void testAnd1() {
+        MyClass m1 = new MyClass();
+
+        // :: error: method.invocation.invalid
+        m1.d();
+    }
+
+    void testAnd2() {
+        MyClass m1 = new MyClass();
+
+        m1.a();
+        // :: error: method.invocation.invalid
+        m1.d();
+    }
+
+    void testAnd3() {
+        MyClass m1 = new MyClass();
+
+        m1.b();
+        // :: error: method.invocation.invalid
+        m1.d();
+    }
+
+    void testAnd4() {
+        MyClass m1 = new MyClass();
+
+        m1.a();
+        m1.c();
+        // :: error: method.invocation.invalid
+        m1.d();
+    }
+
+    void testAnd5() {
+        MyClass m1 = new MyClass();
+
+        m1.a();
+        m1.b();
+        m1.d();
+    }
+
+    void testAnd6() {
+        MyClass m1 = new MyClass();
+
+        m1.a();
+        m1.b();
+        m1.c();
+        m1.d();
+    }
+
+    void testAndOr1() {
+        MyClass m1 = new MyClass();
+
+        // :: error: method.invocation.invalid
+        m1.e();
+    }
+
+    void testAndOr2() {
+        MyClass m1 = new MyClass();
+
+        m1.a();
+        m1.e();
+    }
+
+    void testAndOr3() {
+        MyClass m1 = new MyClass();
+
+        m1.b();
+        // :: error: method.invocation.invalid
+        m1.e();
+    }
+
+    void testAndOr4() {
+        MyClass m1 = new MyClass();
+
+        m1.b();
+        m1.c();
+        m1.e();
+    }
+
+    void testAndOr5() {
+        MyClass m1 = new MyClass();
+
+        m1.a();
+        m1.b();
+        m1.c();
+        m1.d();
+        m1.e();
+    }
+
+    void testPrecedence1() {
+        MyClass m1 = new MyClass();
+
+        // :: error: method.invocation.invalid
+        m1.f();
+    }
+
+    void testPrecedence2() {
+        MyClass m1 = new MyClass();
+
+        m1.a();
+        // :: error: method.invocation.invalid
+        m1.f();
+    }
+
+    void testPrecedence3() {
+        MyClass m1 = new MyClass();
+
+        m1.b();
+        // :: error: method.invocation.invalid
+        m1.f();
+    }
+
+    void testPrecedence4() {
+        MyClass m1 = new MyClass();
+
+        m1.a();
+        m1.b();
+        m1.f();
+    }
+
+    void testPrecedence5() {
+        MyClass m1 = new MyClass();
+
+        m1.a();
+        m1.c();
+        m1.f();
+    }
+
+    void testPrecedence6() {
+        MyClass m1 = new MyClass();
+
+        m1.b();
+        m1.c();
+        m1.f();
+    }
+
+    private class MyClass {
+        void a() { }
+        void b() { }
+        void c(@CalledMethodsPredicate("a || b") MyClass this) { }
+        void d(@CalledMethodsPredicate("a && b") MyClass this) { }
+        void e(@CalledMethodsPredicate("a || (b && c)") MyClass this) { }
+        void f(@CalledMethodsPredicate("a && b || c") MyClass this) { }
+    }
+}

--- a/tests/basic/UnparseablePredicate.java
+++ b/tests/basic/UnparseablePredicate.java
@@ -1,0 +1,10 @@
+import org.checkerframework.checker.builder.qual.*;
+
+class UnparseablePredicate {
+
+    // :: error: predicate.invalid
+    void unclosedOpen(@CalledMethodsPredicate("(foo AND bar") Object x) { }
+
+    // :: error: predicate.invalid
+    void unopenedClose(@CalledMethodsPredicate("foo OR bar)") Object x) { }
+}

--- a/tests/cve/Cve.java
+++ b/tests/cve/Cve.java
@@ -7,11 +7,22 @@ import com.amazonaws.services.ec2.AmazonEC2;
 public class Cve {
     private static final String IMG_NAME = "some_linux_img";
 
-    public static void exec(AmazonEC2 client) {
+    public static void onlyNames(AmazonEC2 client) {
         // Should not be allowed unless .withOwner is also used
-        // :: error: argument.type.incompatible
         DescribeImagesResult result = client.describeImages(new DescribeImagesRequest()
+                // :: error: argument.type.incompatible
                 .withFilters(new Filter("name").withValues(IMG_NAME)));
 
+    }
+
+    public static void correct1(AmazonEC2 client) {
+        DescribeImagesResult result = client.describeImages(new DescribeImagesRequest()
+                .withFilters(new Filter("name").withValues(IMG_NAME))
+                .withOwners("martin"));
+    }
+
+    public static void correct2(AmazonEC2 client) {
+        DescribeImagesResult result = client.describeImages(new DescribeImagesRequest()
+                .withImageIds("myImageId"));
     }
 }

--- a/tests/cve/Cve.java
+++ b/tests/cve/Cve.java
@@ -1,16 +1,17 @@
 import com.amazonaws.services.ec2.model.DescribeImagesRequest;
 import com.amazonaws.services.ec2.model.DescribeImagesResult;
 import com.amazonaws.services.ec2.model.Filter;
+import com.amazonaws.services.ec2.AmazonEC2;
 
 // https://nvd.nist.gov/vuln/detail/CVE-2018-15869
 public class Cve {
     private static final String IMG_NAME = "some_linux_img";
 
-    public static void main(String args[]) {
+    public static void exec(AmazonEC2 client) {
         // Should not be allowed unless .withOwner is also used
+        // :: error: argument.type.incompatible
         DescribeImagesResult result = client.describeImages(new DescribeImagesRequest()
                 .withFilters(new Filter("name").withValues(IMG_NAME)));
 
     }
-
 }

--- a/tests/cve/Cve2.java
+++ b/tests/cve/Cve2.java
@@ -1,0 +1,33 @@
+import com.amazonaws.services.ec2.model.DescribeImagesRequest;
+import com.amazonaws.services.ec2.model.DescribeImagesResult;
+import com.amazonaws.services.ec2.model.Filter;
+import com.amazonaws.services.ec2.AmazonEC2;
+
+// https://nvd.nist.gov/vuln/detail/CVE-2018-15869
+public class Cve2 {
+    private static final String IMG_NAME = "some_linux_img";
+
+    public static void onlyNames(AmazonEC2 client) {
+        // Should not be allowed unless .withOwner is also used
+        DescribeImagesRequest request = new DescribeImagesRequest();
+        request.withFilters(new Filter("name").withValues(IMG_NAME));
+
+        // :: error: argument.type.incompatible
+        DescribeImagesResult result = client.describeImages(request);
+    }
+
+    public static void correct1(AmazonEC2 client) {
+        DescribeImagesRequest request = new DescribeImagesRequest();
+        request.withFilters(new Filter("name").withValues(IMG_NAME));
+        request.withOwners("martin");
+
+        DescribeImagesResult result = client.describeImages(request);
+    }
+
+    public static void correct2(AmazonEC2 client) {
+        DescribeImagesRequest request = new DescribeImagesRequest();
+        request.withImageIds("myImageId");
+
+        DescribeImagesResult result = client.describeImages(request);
+    }
+}


### PR DESCRIPTION
This pull request adds support for a new annotation in the `@CalledMethods` type system: `@CalledMethodsPredicate`. This annotation exists to generically extend the possibly least upper bounds that are expressible in this type system by permitting disjunctions.

The motivation for this addition to the type system is that there are builders (and other kinds of situations) where we want to permit a few different _combinations_ of called methods. Take, for example, this example in `tests/cve/Cve.java`, which is an AWS API that is vulnerable to a so-called "AMI sniping" attack (which permits malicious code injection) if one of the logical parameters is specified without another. However, another safe set of calls uses a totally different parameter, and ignores the other two calls. The stub file with the (full) specification for this API is in the `stubs/DescribeImages.astub` file (the reason for the proliferation of `||`s in the spec is that these AWS APIs have two methods to supply each parameter: one fluent, and one side-effectful).

I implemented a simple predicate language using the [Javaluator](http://javaluator.sourceforge.net/en/home/) framework, which seemed like a good choice because I didn't want to re-implement a recursive descent parser from scratch.

The primary changes in this pull request are:
- The new annotation `@CalledMethodsPredicate`, and a new unified top annotation so that `@CalledMethodsPredicate` and `@CalledMethods` are siblings in the type hierarchy and are unassignable except via the mechanism in the new subtyping relationship
- An evaluator, built on top of Javaluator, which determines whether a given predicate is true or false given a set of methods that have been called on an object
- Modifications to the subtyping, glb, and lub algorithms to support the new annotation
- Basic tests for the new annotation and some simple predicates
- A visitor for the type system that rejects (some) mis-formed predicates with a special error message
- A test that enforces that predicates with unbalanced parentheses are rejected
- A new test set that expands on Martin Schaef's CVE test by including both correct and incorrect calls, and both fluent and non-fluent examples