### PR TITLE
Replace Javaluator with SPEL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     implementation 'org.checkerframework:checker:2.8.1'
 
     // For the @CalledMethodsPredicate evaluation
-    implementation 'com.fathzer:javaluator:3.0.2'
+    implementation 'org.springframework:spring-expression:5.1.7.RELEASE'
 
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'

--- a/src/main/java/org/checkerframework/checker/builder/CalledMethodsPredicateEvaluator.java
+++ b/src/main/java/org/checkerframework/checker/builder/CalledMethodsPredicateEvaluator.java
@@ -1,72 +1,36 @@
 package org.checkerframework.checker.builder;
 
-import com.fathzer.soft.javaluator.AbstractEvaluator;
-import com.fathzer.soft.javaluator.BracketPair;
-import com.fathzer.soft.javaluator.Operator;
-import com.fathzer.soft.javaluator.Parameters;
+import org.springframework.expression.Expression;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
 
-import java.util.Iterator;
 import java.util.Set;
 
 /**
  * This class parses and evaluates a single @CalledMethodsPredicate argument.
- * It is based on an answer to this StackOverflow question:
- * https://stackoverflow.com/questions/12203003/boolean-expression-parser-in-java
  */
-public class CalledMethodsPredicateEvaluator extends AbstractEvaluator<String> {
-    /**
-     * The logical AND operator.
-     */
-    private final static Operator AND =
-            new Operator("&&", 2, Operator.Associativity.LEFT, 2);
-    /**
-     * The logical OR operator.
-     */
-    private final static Operator OR =
-            new Operator("||", 2, Operator.Associativity.LEFT, 1);
-
-    private static final Parameters PARAMETERS;
+public class CalledMethodsPredicateEvaluator {
 
     // A set containing all the names of methods that ought to evaluate to true.
     private final Set<String> cmMethods;
 
-    static {
-        // Create the evaluator's parameters
-        PARAMETERS = new Parameters();
-        // Add the supported operators
-        PARAMETERS.add(AND);
-        PARAMETERS.add(OR);
-        // Add the parentheses
-        PARAMETERS.addExpressionBracket(BracketPair.PARENTHESES);
-    }
-
     public CalledMethodsPredicateEvaluator(final Set<String> cmMethods) {
-        super(PARAMETERS);
         this.cmMethods = cmMethods;
     }
 
-    @Override
-    protected String toValue(final String literal, final Object evaluationContext) {
-        return literal;
-    }
+    protected boolean evaluate(String expression) {
 
-    private boolean getValue(final String literal) {
-        return cmMethods.contains(literal) || "true".equals(literal);
-    }
-
-    @Override
-    protected String evaluate(final Operator operator, final Iterator<String> operands,
-                              final Object evaluationContext) {
-        String o1 = operands.next();
-        String o2 = operands.next();
-        Boolean result;
-        if (operator == OR) {
-            result = getValue(o1) || getValue(o2);
-        } else if (operator == AND) {
-            result = getValue(o1) && getValue(o2);
-        } else {
-            throw new IllegalArgumentException();
+        for (String cmMethod : cmMethods) {
+            expression = expression.replaceAll(cmMethod, "true");
         }
-        return result.toString();
+
+        expression = expression.replaceAll("((?!true)[a-zA-Z0-9])+", "false");
+
+        // horrible hack but I can't figure out the right regex to make the above not replace "true" with "tfalse"
+        expression = expression.replaceAll("tfalse", "true");
+
+        ExpressionParser parser = new SpelExpressionParser();
+        Expression exp = parser.parseExpression(expression);
+        return exp.getValue(Boolean.class);
     }
 }

--- a/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderAnnotatedTypeFactory.java
+++ b/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderAnnotatedTypeFactory.java
@@ -200,8 +200,7 @@ public class TypesafeBuilderAnnotatedTypeFactory extends BaseAnnotatedTypeFactor
                 // superAnno is a CMP annotation, so we need to evaluate the predicate
                 String predicate = AnnotationUtils.getElementValue(superAnno, "value", String.class, false);
                 CalledMethodsPredicateEvaluator evaluator = new CalledMethodsPredicateEvaluator(subVal);
-                String result = evaluator.evaluate(predicate);
-                return Boolean.parseBoolean(result);
+                return evaluator.evaluate(predicate);
             } else {
                 // superAnno is a CM annotation, so compare the sets
                 return subVal.containsAll(getValueOfAnnotationWithStringArgument(superAnno));

--- a/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderVisitor.java
+++ b/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderVisitor.java
@@ -7,9 +7,9 @@ import org.checkerframework.common.basetype.BaseTypeVisitor;
 import org.checkerframework.framework.source.Result;
 import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.TreeUtils;
+import org.springframework.expression.spel.SpelParseException;
 
 import javax.lang.model.element.AnnotationMirror;
-import java.util.ArrayList;
 import java.util.Collections;
 
 public class TypesafeBuilderVisitor extends BaseTypeVisitor<TypesafeBuilderAnnotatedTypeFactory> {
@@ -31,8 +31,8 @@ public class TypesafeBuilderVisitor extends BaseTypeVisitor<TypesafeBuilderAnnot
                     AnnotationUtils.getElementValue(anno, "value", String.class, false);
 
             try {
-                new CalledMethodsPredicateEvaluator(Collections.emptySet()).evaluate(predicate, new ArrayList<>());
-            } catch (IllegalArgumentException e) {
+                new CalledMethodsPredicateEvaluator(Collections.emptySet()).evaluate(predicate);
+            } catch (SpelParseException e) {
                 checker.report(Result.failure("predicate.invalid", e.getMessage()), node);
                 return null;
             }


### PR DESCRIPTION
For evaluating `@CalledMethodsPredicate`. There should be no functional difference, but SPEL uses the Apache license, while Javaluator is LGPL3, which isn't really compatible with the license on this repository.

As a bonus, the code is simpler. There's a horrible hack in there because I'm terrible at regular expressions, but for now that should be okay. @martinschaef, you should be able to use this branch in your experiments.