### PR TITLE
Enforce style

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,8 @@ plugins {
     id 'io.spring.dependency-management' version '1.0.7.RELEASE'
 
     id 'maven-publish'
+
+    id "com.diffplug.gradle.spotless" version "3.23.0"
 }
 
 repositories {
@@ -46,14 +48,21 @@ tasks.withType(JavaCompile).all {
     options.compilerArgs.add("-Xlint:all")
 }
 
-    publishing {
-        publications {
-            maven(MavenPublication) {
-                groupId = 'org.checkerframework'
-                artifactId = 'typesafe-builder'
-                version = '0.1-SNAPSHOT'
+publishing {
+    publications {
+        maven(MavenPublication) {
+            groupId = 'org.checkerframework'
+            artifactId = 'typesafe-builder'
+            version = '0.1-SNAPSHOT'
 
-                from components.java
-            }
+            from components.java
         }
     }
+}
+
+// run google java format
+spotless {
+    java {
+        googleJavaFormat()
+    }
+}

--- a/src/main/java/org/checkerframework/checker/builder/CalledMethodsPredicateEvaluator.java
+++ b/src/main/java/org/checkerframework/checker/builder/CalledMethodsPredicateEvaluator.java
@@ -1,36 +1,34 @@
 package org.checkerframework.checker.builder;
 
+import java.util.Set;
 import org.springframework.expression.Expression;
 import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 
-import java.util.Set;
-
-/**
- * This class parses and evaluates a single @CalledMethodsPredicate argument.
- */
+/** This class parses and evaluates a single @CalledMethodsPredicate argument. */
 public class CalledMethodsPredicateEvaluator {
 
-    // A set containing all the names of methods that ought to evaluate to true.
-    private final Set<String> cmMethods;
+  // A set containing all the names of methods that ought to evaluate to true.
+  private final Set<String> cmMethods;
 
-    public CalledMethodsPredicateEvaluator(final Set<String> cmMethods) {
-        this.cmMethods = cmMethods;
+  public CalledMethodsPredicateEvaluator(final Set<String> cmMethods) {
+    this.cmMethods = cmMethods;
+  }
+
+  protected boolean evaluate(String expression) {
+
+    for (String cmMethod : cmMethods) {
+      expression = expression.replaceAll(cmMethod, "true");
     }
 
-    protected boolean evaluate(String expression) {
+    expression = expression.replaceAll("((?!true)[a-zA-Z0-9])+", "false");
 
-        for (String cmMethod : cmMethods) {
-            expression = expression.replaceAll(cmMethod, "true");
-        }
+    // horrible hack but I can't figure out the right regex to make the above not replace "true"
+    // with "tfalse"
+    expression = expression.replaceAll("tfalse", "true");
 
-        expression = expression.replaceAll("((?!true)[a-zA-Z0-9])+", "false");
-
-        // horrible hack but I can't figure out the right regex to make the above not replace "true" with "tfalse"
-        expression = expression.replaceAll("tfalse", "true");
-
-        ExpressionParser parser = new SpelExpressionParser();
-        Expression exp = parser.parseExpression(expression);
-        return exp.getValue(Boolean.class);
-    }
+    ExpressionParser parser = new SpelExpressionParser();
+    Expression exp = parser.parseExpression(expression);
+    return exp.getValue(Boolean.class);
+  }
 }

--- a/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderAnnotatedTypeFactory.java
+++ b/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderAnnotatedTypeFactory.java
@@ -2,6 +2,13 @@ package org.checkerframework.checker.builder;
 
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
 import org.checkerframework.checker.builder.qual.CalledMethods;
 import org.checkerframework.checker.builder.qual.CalledMethodsBottom;
 import org.checkerframework.checker.builder.qual.CalledMethodsPredicate;
@@ -19,203 +26,196 @@ import org.checkerframework.javacutil.AnnotationBuilder;
 import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.TreeUtils;
 
-import javax.lang.model.element.AnnotationMirror;
-import javax.lang.model.element.Element;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
-
 /**
- * The annotated type factory for the typesafe builder checker. Primarily responsible
- * for the subtyping rules between @CalledMethod annotations.
+ * The annotated type factory for the typesafe builder checker. Primarily responsible for the
+ * subtyping rules between @CalledMethod annotations.
  */
 public class TypesafeBuilderAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
-    /**
-     * Canonical copies of the top and bottom annotations. Package private to permit access
-     * from the Transfer class.
-     */
-    final AnnotationMirror TOP, BOTTOM;
+  /**
+   * Canonical copies of the top and bottom annotations. Package private to permit access from the
+   * Transfer class.
+   */
+  final AnnotationMirror TOP, BOTTOM;
 
-    /**
-     * Default constructor matching super. Should be called automatically.
-     */
-    public TypesafeBuilderAnnotatedTypeFactory(final BaseTypeChecker checker) {
-        super(checker);
-        TOP = AnnotationBuilder.fromClass(elements, CalledMethodsTop.class);
-        BOTTOM = AnnotationBuilder.fromClass(elements, CalledMethodsBottom.class);
-        this.postInit();
+  /** Default constructor matching super. Should be called automatically. */
+  public TypesafeBuilderAnnotatedTypeFactory(final BaseTypeChecker checker) {
+    super(checker);
+    TOP = AnnotationBuilder.fromClass(elements, CalledMethodsTop.class);
+    BOTTOM = AnnotationBuilder.fromClass(elements, CalledMethodsBottom.class);
+    this.postInit();
+  }
+
+  /** Creates a @CalledMethods annotation whose values are the given strings. */
+  public AnnotationMirror createCalledMethods(final String... val) {
+    if (val.length == 0) {
+      return TOP;
     }
+    AnnotationBuilder builder = new AnnotationBuilder(processingEnv, CalledMethods.class);
+    Arrays.sort(val);
+    builder.setValue("value", val);
+    return builder.build();
+  }
 
-    /** Creates a @CalledMethods annotation whose values are the given strings. */
-    public AnnotationMirror createCalledMethods(final String... val) {
-        if (val.length == 0) {
-            return TOP;
-        }
-        AnnotationBuilder builder = new AnnotationBuilder(processingEnv, CalledMethods.class);
-        Arrays.sort(val);
-        builder.setValue("value", val);
-        return builder.build();
+  @Override
+  public TreeAnnotator createTreeAnnotator() {
+    return new ListTreeAnnotator(
+        super.createTreeAnnotator(), new TypesafeBuilderTreeAnnotator(this));
+  }
+
+  @Override
+  public QualifierHierarchy createQualifierHierarchy(
+      final MultiGraphQualifierHierarchy.MultiGraphFactory factory) {
+    return new TypesafeBuilderQualifierHierarchy(factory);
+  }
+
+  /**
+   * This tree annotator is needed to create types for fluent builders that have @ReturnsReceiver
+   * annotations.
+   */
+  private class TypesafeBuilderTreeAnnotator extends TreeAnnotator {
+    public TypesafeBuilderTreeAnnotator(final AnnotatedTypeFactory atypeFactory) {
+      super(atypeFactory);
     }
 
     @Override
-    public TreeAnnotator createTreeAnnotator() {
-        return new ListTreeAnnotator(super.createTreeAnnotator(), new TypesafeBuilderTreeAnnotator(this));
+    public Void visitMethodInvocation(
+        final MethodInvocationTree tree, final AnnotatedTypeMirror type) {
+
+      // Check to see if the @ReturnsReceiver annotation is present
+      Element element = TreeUtils.elementFromUse(tree);
+      AnnotationMirror returnsReceiver = getDeclAnnotation(element, ReturnsReceiver.class);
+
+      if (returnsReceiver != null) {
+
+        // Fetch the current type of the receiver, or top if none exists
+        ExpressionTree receiverTree = TreeUtils.getReceiverTree(tree.getMethodSelect());
+        AnnotatedTypeMirror receiverType = getAnnotatedType(receiverTree);
+        AnnotationMirror receiverAnno = receiverType.getAnnotationInHierarchy(TOP);
+        if (receiverAnno == null) {
+          receiverAnno = TOP;
+        }
+
+        // Construct a new @CM annotation with just the method name
+        String methodName = TreeUtils.methodName(tree).toString();
+        AnnotationMirror cmAnno = createCalledMethods(methodName);
+
+        // Replace the return type of the method with the GLB (= union) of the two types above
+        AnnotationMirror newAnno = getQualifierHierarchy().greatestLowerBound(cmAnno, receiverAnno);
+        type.replaceAnnotation(newAnno);
+      }
+
+      return super.visitMethodInvocation(tree, type);
+    }
+  }
+
+  /**
+   * The qualifier hierarchy is responsible for lub, glb, and subtyping between qualifiers without
+   * declaratively defined subtyping relationships, like our @CalledMethods annotation.
+   */
+  private class TypesafeBuilderQualifierHierarchy extends MultiGraphQualifierHierarchy {
+    public TypesafeBuilderQualifierHierarchy(
+        final MultiGraphQualifierHierarchy.MultiGraphFactory factory) {
+      super(factory);
     }
 
     @Override
-    public QualifierHierarchy createQualifierHierarchy(final MultiGraphQualifierHierarchy.MultiGraphFactory factory) {
-        return new TypesafeBuilderQualifierHierarchy(factory);
+    public AnnotationMirror getTopAnnotation(final AnnotationMirror start) {
+      return TOP;
     }
 
     /**
-     * This tree annotator is needed to create types for fluent builders
-     * that have @ReturnsReceiver annotations.
+     * GLB in this type system is set union of the arguments of the two annotations, unless one of
+     * them is bottom, in which case the result is also bottom.
      */
-    private class TypesafeBuilderTreeAnnotator extends TreeAnnotator {
-        public TypesafeBuilderTreeAnnotator(final AnnotatedTypeFactory atypeFactory) {
-            super(atypeFactory);
-        }
+    @Override
+    public AnnotationMirror greatestLowerBound(
+        final AnnotationMirror a1, final AnnotationMirror a2) {
+      if (AnnotationUtils.areSame(a1, BOTTOM) || AnnotationUtils.areSame(a2, BOTTOM)) {
+        return BOTTOM;
+      }
 
-        @Override
-        public Void visitMethodInvocation(final MethodInvocationTree tree, final AnnotatedTypeMirror type) {
+      if (!AnnotationUtils.hasElementValue(a1, "value")) {
+        return a2;
+      }
 
-            // Check to see if the @ReturnsReceiver annotation is present
-            Element element = TreeUtils.elementFromUse(tree);
-            AnnotationMirror returnsReceiver = getDeclAnnotation(element, ReturnsReceiver.class);
+      if (!AnnotationUtils.hasElementValue(a2, "value")) {
+        return a1;
+      }
 
-            if (returnsReceiver != null) {
-
-                // Fetch the current type of the receiver, or top if none exists
-                ExpressionTree receiverTree = TreeUtils.getReceiverTree(tree.getMethodSelect());
-                AnnotatedTypeMirror receiverType = getAnnotatedType(receiverTree);
-                AnnotationMirror receiverAnno = receiverType.getAnnotationInHierarchy(TOP);
-                if (receiverAnno == null) {
-                    receiverAnno = TOP;
-                }
-
-                // Construct a new @CM annotation with just the method name
-                String methodName = TreeUtils.methodName(tree).toString();
-                AnnotationMirror cmAnno = createCalledMethods(methodName);
-
-                // Replace the return type of the method with the GLB (= union) of the two types above
-                AnnotationMirror newAnno = getQualifierHierarchy().greatestLowerBound(cmAnno, receiverAnno);
-                type.replaceAnnotation(newAnno);
-            }
-
-            return super.visitMethodInvocation(tree, type);
-        }
+      Set<String> a1Val = new LinkedHashSet<>(getValueOfAnnotationWithStringArgument(a1));
+      Set<String> a2Val = new LinkedHashSet<>(getValueOfAnnotationWithStringArgument(a2));
+      a1Val.addAll(a2Val);
+      return createCalledMethods(a1Val.toArray(new String[0]));
     }
 
     /**
-     * The qualifier hierarchy is responsible for lub, glb, and subtyping between qualifiers without
-     * declaratively defined subtyping relationships, like our @CalledMethods annotation.
+     * LUB in this type system is set intersection of the arguments of the two annotations, unless
+     * one of them is bottom, in which case the result is the other annotation.
      */
-    private class TypesafeBuilderQualifierHierarchy extends MultiGraphQualifierHierarchy {
-        public TypesafeBuilderQualifierHierarchy(final MultiGraphQualifierHierarchy.MultiGraphFactory factory) {
-            super(factory);
-        }
+    @Override
+    public AnnotationMirror leastUpperBound(final AnnotationMirror a1, final AnnotationMirror a2) {
+      if (AnnotationUtils.areSame(a1, BOTTOM)) {
+        return a2;
+      } else if (AnnotationUtils.areSame(a2, BOTTOM)) {
+        return a1;
+      }
 
-        @Override
-        public AnnotationMirror getTopAnnotation(final AnnotationMirror start) {
-            return TOP;
-        }
+      if (!AnnotationUtils.hasElementValue(a1, "value")) {
+        return a1;
+      }
 
-        /**
-         * GLB in this type system is set union of the arguments of the two annotations,
-         * unless one of them is bottom, in which case the result is also bottom.
-         */
-        @Override
-        public AnnotationMirror greatestLowerBound(final AnnotationMirror a1, final AnnotationMirror a2) {
-            if (AnnotationUtils.areSame(a1, BOTTOM) || AnnotationUtils.areSame(a2, BOTTOM)) {
-                return BOTTOM;
-            }
+      if (!AnnotationUtils.hasElementValue(a2, "value")) {
+        return a2;
+      }
 
-            if (!AnnotationUtils.hasElementValue(a1, "value")) {
-                return a2;
-            }
-
-            if (!AnnotationUtils.hasElementValue(a2, "value")) {
-                return a1;
-            }
-
-            Set<String> a1Val = new LinkedHashSet<>(getValueOfAnnotationWithStringArgument(a1));
-            Set<String> a2Val = new LinkedHashSet<>(getValueOfAnnotationWithStringArgument(a2));
-            a1Val.addAll(a2Val);
-            return createCalledMethods(a1Val.toArray(new String[0]));
-        }
-
-        /**
-         * LUB in this type system is set intersection of the arguments of the two annotations,
-         * unless one of them is bottom, in which case the result is the other annotation.
-         */
-        @Override
-        public AnnotationMirror leastUpperBound(final AnnotationMirror a1, final AnnotationMirror a2) {
-            if (AnnotationUtils.areSame(a1, BOTTOM)) {
-                return a2;
-            } else if (AnnotationUtils.areSame(a2, BOTTOM)) {
-                return a1;
-            }
-
-            if (!AnnotationUtils.hasElementValue(a1, "value")) {
-                return a1;
-            }
-
-            if (!AnnotationUtils.hasElementValue(a2, "value")) {
-                return a2;
-            }
-
-            Set<String> a1Val = new LinkedHashSet<>(getValueOfAnnotationWithStringArgument(a1));
-            Set<String> a2Val = new LinkedHashSet<>(getValueOfAnnotationWithStringArgument(a2));
-            a1Val.retainAll(a2Val);
-            return createCalledMethods(a1Val.toArray(new String[0]));
-        }
-
-        /**
-         * isSubtype in this type system is subset
-         */
-        @Override
-        public boolean isSubtype(final AnnotationMirror subAnno, final AnnotationMirror superAnno) {
-            if (AnnotationUtils.areSame(subAnno, BOTTOM)) {
-                return true;
-            } else if (AnnotationUtils.areSame(superAnno, BOTTOM)) {
-                return false;
-            }
-
-            if (AnnotationUtils.areSame(superAnno, TOP)) {
-                return true;
-            } else if (AnnotationUtils.areSame(subAnno, TOP)) {
-                return false;
-            }
-
-            if (AnnotationUtils.areSameByClass(subAnno, CalledMethodsPredicate.class)) {
-                return false;
-            }
-
-            Set<String> subVal = new LinkedHashSet<>(getValueOfAnnotationWithStringArgument(subAnno));
-
-            if (AnnotationUtils.areSameByClass(superAnno, CalledMethodsPredicate.class)) {
-                // superAnno is a CMP annotation, so we need to evaluate the predicate
-                String predicate = AnnotationUtils.getElementValue(superAnno, "value", String.class, false);
-                CalledMethodsPredicateEvaluator evaluator = new CalledMethodsPredicateEvaluator(subVal);
-                return evaluator.evaluate(predicate);
-            } else {
-                // superAnno is a CM annotation, so compare the sets
-                return subVal.containsAll(getValueOfAnnotationWithStringArgument(superAnno));
-            }
-        }
+      Set<String> a1Val = new LinkedHashSet<>(getValueOfAnnotationWithStringArgument(a1));
+      Set<String> a2Val = new LinkedHashSet<>(getValueOfAnnotationWithStringArgument(a2));
+      a1Val.retainAll(a2Val);
+      return createCalledMethods(a1Val.toArray(new String[0]));
     }
 
-    /**
-     * Gets the value field of an annotation with a list of strings in its value field.
-     * The empty list is returned if no value field is defined.
-     */
-    public static List<String> getValueOfAnnotationWithStringArgument(final AnnotationMirror anno) {
-        if (!AnnotationUtils.hasElementValue(anno, "value")) {
-            return Collections.emptyList();
-        }
-        return AnnotationUtils.getElementValueArray(anno, "value", String.class, true);
+    /** isSubtype in this type system is subset */
+    @Override
+    public boolean isSubtype(final AnnotationMirror subAnno, final AnnotationMirror superAnno) {
+      if (AnnotationUtils.areSame(subAnno, BOTTOM)) {
+        return true;
+      } else if (AnnotationUtils.areSame(superAnno, BOTTOM)) {
+        return false;
+      }
+
+      if (AnnotationUtils.areSame(superAnno, TOP)) {
+        return true;
+      } else if (AnnotationUtils.areSame(subAnno, TOP)) {
+        return false;
+      }
+
+      if (AnnotationUtils.areSameByClass(subAnno, CalledMethodsPredicate.class)) {
+        return false;
+      }
+
+      Set<String> subVal = new LinkedHashSet<>(getValueOfAnnotationWithStringArgument(subAnno));
+
+      if (AnnotationUtils.areSameByClass(superAnno, CalledMethodsPredicate.class)) {
+        // superAnno is a CMP annotation, so we need to evaluate the predicate
+        String predicate = AnnotationUtils.getElementValue(superAnno, "value", String.class, false);
+        CalledMethodsPredicateEvaluator evaluator = new CalledMethodsPredicateEvaluator(subVal);
+        return evaluator.evaluate(predicate);
+      } else {
+        // superAnno is a CM annotation, so compare the sets
+        return subVal.containsAll(getValueOfAnnotationWithStringArgument(superAnno));
+      }
     }
+  }
+
+  /**
+   * Gets the value field of an annotation with a list of strings in its value field. The empty list
+   * is returned if no value field is defined.
+   */
+  public static List<String> getValueOfAnnotationWithStringArgument(final AnnotationMirror anno) {
+    if (!AnnotationUtils.hasElementValue(anno, "value")) {
+      return Collections.emptyList();
+    }
+    return AnnotationUtils.getElementValueArray(anno, "value", String.class, true);
+  }
 }

--- a/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderChecker.java
+++ b/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderChecker.java
@@ -4,11 +4,9 @@ import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.framework.source.SuppressWarningsKeys;
 
 /**
- * The primary typechecker for the typesafe builder checker,
- * which allows programmers to specify unsafe combinations of
- * options to builder or builder-like interfaces and prevent
- * dangerous objects from being instantiated.
+ * The primary typechecker for the typesafe builder checker, which allows programmers to specify
+ * unsafe combinations of options to builder or builder-like interfaces and prevent dangerous
+ * objects from being instantiated.
  */
 @SuppressWarningsKeys({"builder", "typesafe.builder"})
-public class TypesafeBuilderChecker extends BaseTypeChecker {
-}
+public class TypesafeBuilderChecker extends BaseTypeChecker {}

--- a/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderVisitor.java
+++ b/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderVisitor.java
@@ -1,6 +1,8 @@
 package org.checkerframework.checker.builder;
 
 import com.sun.source.tree.AnnotationTree;
+import java.util.Collections;
+import javax.lang.model.element.AnnotationMirror;
 import org.checkerframework.checker.builder.qual.CalledMethodsPredicate;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.basetype.BaseTypeVisitor;
@@ -9,34 +11,26 @@ import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.TreeUtils;
 import org.springframework.expression.spel.SpelParseException;
 
-import javax.lang.model.element.AnnotationMirror;
-import java.util.Collections;
-
 public class TypesafeBuilderVisitor extends BaseTypeVisitor<TypesafeBuilderAnnotatedTypeFactory> {
-    /**
-     * @param checker the type-checker associated with this visitor
-     */
-    public TypesafeBuilderVisitor(final BaseTypeChecker checker) {
-        super(checker);
-    }
+  /** @param checker the type-checker associated with this visitor */
+  public TypesafeBuilderVisitor(final BaseTypeChecker checker) {
+    super(checker);
+  }
 
-    /**
-     * Checks each @CalledMethodsPredicate annotation to make sure the predicate is well-formed.
-     */
-    @Override
-    public Void visitAnnotation(final AnnotationTree node, final Void p) {
-        AnnotationMirror anno = TreeUtils.annotationFromAnnotationTree(node);
-        if (AnnotationUtils.areSameByClass(anno, CalledMethodsPredicate.class)) {
-            String predicate =
-                    AnnotationUtils.getElementValue(anno, "value", String.class, false);
+  /** Checks each @CalledMethodsPredicate annotation to make sure the predicate is well-formed. */
+  @Override
+  public Void visitAnnotation(final AnnotationTree node, final Void p) {
+    AnnotationMirror anno = TreeUtils.annotationFromAnnotationTree(node);
+    if (AnnotationUtils.areSameByClass(anno, CalledMethodsPredicate.class)) {
+      String predicate = AnnotationUtils.getElementValue(anno, "value", String.class, false);
 
-            try {
-                new CalledMethodsPredicateEvaluator(Collections.emptySet()).evaluate(predicate);
-            } catch (SpelParseException e) {
-                checker.report(Result.failure("predicate.invalid", e.getMessage()), node);
-                return null;
-            }
-        }
-        return super.visitAnnotation(node, p);
+      try {
+        new CalledMethodsPredicateEvaluator(Collections.emptySet()).evaluate(predicate);
+      } catch (SpelParseException e) {
+        checker.report(Result.failure("predicate.invalid", e.getMessage()), node);
+        return null;
+      }
     }
+    return super.visitAnnotation(node, p);
+  }
 }

--- a/src/main/java/org/checkerframework/checker/builder/qual/CalledMethods.java
+++ b/src/main/java/org/checkerframework/checker/builder/qual/CalledMethods.java
@@ -1,23 +1,22 @@
 package org.checkerframework.checker.builder.qual;
 
-import org.checkerframework.framework.qual.SubtypeOf;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.checkerframework.framework.qual.SubtypeOf;
 
 /**
- * This annotation keeps track of the methods called on an object.
- * It mostly forms its own lattice: @CalledMethods({}) is top,
- * and @CalledMethods(A) is a subtype of @CalledMethod(B) iff B is a subset of a A.
+ * This annotation keeps track of the methods called on an object. It mostly forms its own
+ * lattice: @CalledMethods({}) is top, and @CalledMethods(A) is a subtype of @CalledMethod(B) iff B
+ * is a subset of a A.
  *
- * There is also a bottom annotation.
+ * <p>There is also a bottom annotation.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf({CalledMethodsTop.class})
 public @interface CalledMethods {
-    /** A list of methods that have been called on the annotated object. */
-    public String[] value() default {};
+  /** A list of methods that have been called on the annotated object. */
+  public String[] value() default {};
 }

--- a/src/main/java/org/checkerframework/checker/builder/qual/CalledMethodsBottom.java
+++ b/src/main/java/org/checkerframework/checker/builder/qual/CalledMethodsBottom.java
@@ -1,27 +1,23 @@
 package org.checkerframework.checker.builder.qual;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.ImplicitFor;
 import org.checkerframework.framework.qual.LiteralKind;
 import org.checkerframework.framework.qual.SubtypeOf;
 import org.checkerframework.framework.qual.TargetLocations;
 import org.checkerframework.framework.qual.TypeUseLocation;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
 /**
- * The bottom type for the CalledMethods type system,
- * a part of the typesafe builder checker.
+ * The bottom type for the CalledMethods type system, a part of the typesafe builder checker.
  *
- * It should rarely, if ever, be written by a programmer.
+ * <p>It should rarely, if ever, be written by a programmer.
  */
-
 @SubtypeOf({CalledMethods.class, CalledMethodsPredicate.class})
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
 @ImplicitFor(literals = LiteralKind.NULL, typeNames = java.lang.Void.class)
-public @interface CalledMethodsBottom {
-}
+public @interface CalledMethodsBottom {}

--- a/src/main/java/org/checkerframework/checker/builder/qual/CalledMethodsPredicate.java
+++ b/src/main/java/org/checkerframework/checker/builder/qual/CalledMethodsPredicate.java
@@ -1,34 +1,28 @@
 package org.checkerframework.checker.builder.qual;
 
-import org.checkerframework.framework.qual.SubtypeOf;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.checkerframework.framework.qual.SubtypeOf;
 
 /**
- * This annotation represents a predicate on @CalledMethods
- * annotations that must be true. It is intended to extend
- * the possible LUB of the @CalledMethods type system to
- * permit methods to be annotated to require a disjunction
- * of method calls. So, for instance, if it was acceptable
- * to call method a() or method b() before calling method c(),
- * then c()'s receiver should have an @CalledMethodsPredicate
- * annotation with the argument "a || b"
+ * This annotation represents a predicate on @CalledMethods annotations that must be true. It is
+ * intended to extend the possible LUB of the @CalledMethods type system to permit methods to be
+ * annotated to require a disjunction of method calls. So, for instance, if it was acceptable to
+ * call method a() or method b() before calling method c(), then c()'s receiver should have
+ * an @CalledMethodsPredicate annotation with the argument "a || b"
  *
- * The argument is a string. The string must be constructed
- * from the following grammar:
+ * <p>The argument is a string. The string must be constructed from the following grammar:
  *
- * S → method name | (S) | S && S | S || S
+ * <p>S → method name | (S) | S && S | S || S
  *
- * That is, the permitted elements are method names, parentheses,
- * and the strings "&&" and "||". "&&" has higher precedence
- * than "||", following standard Java operator semantics.
+ * <p>That is, the permitted elements are method names, parentheses, and the strings "&&" and "||".
+ * "&&" has higher precedence than "||", following standard Java operator semantics.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf({CalledMethodsTop.class})
 public @interface CalledMethodsPredicate {
-    String value();
+  String value();
 }

--- a/src/main/java/org/checkerframework/checker/builder/qual/CalledMethodsTop.java
+++ b/src/main/java/org/checkerframework/checker/builder/qual/CalledMethodsTop.java
@@ -1,21 +1,19 @@
 package org.checkerframework.checker.builder.qual;
 
-import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
-import org.checkerframework.framework.qual.SubtypeOf;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
+import org.checkerframework.framework.qual.SubtypeOf;
 
 /**
  * The default qualifier in the hierarchy. It is equivalent to @CalledMethods({}).
  *
- * Needed so that @CalledMethodsPredicate can be a sibling of @CalledMethods.
+ * <p>Needed so that @CalledMethodsPredicate can be a sibling of @CalledMethods.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @DefaultQualifierInHierarchy
 @SubtypeOf({})
-public @interface CalledMethodsTop {
-}
+public @interface CalledMethodsTop {}

--- a/src/main/java/org/checkerframework/checker/builder/qual/ReturnsReceiver.java
+++ b/src/main/java/org/checkerframework/checker/builder/qual/ReturnsReceiver.java
@@ -7,21 +7,19 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This declaration annotation indicates that the method on which
- * it is written returns exactly the receiver object.
+ * This declaration annotation indicates that the method on which it is written returns exactly the
+ * receiver object.
  *
- * The annotation is used by the Typesafe Builder Checker to
- * determine whether to copy @CalledMethods annotations from one
- * invocation of a builder's methods to others in a fluent builder
- * chain.
+ * <p>The annotation is used by the Typesafe Builder Checker to determine whether to
+ * copy @CalledMethods annotations from one invocation of a builder's methods to others in a fluent
+ * builder chain.
  *
- * This annotation can only be written on a method declaration.
- * It is inherited by all overrides of that method.
+ * <p>This annotation can only be written on a method declaration. It is inherited by all overrides
+ * of that method.
  *
- * TODO: describe how this is checked, or whether it is trusted
+ * <p>TODO: describe how this is checked, or whether it is trusted
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 @Inherited
-public @interface ReturnsReceiver {
-}
+public @interface ReturnsReceiver {}

--- a/src/test/java/tests/BasicTest.java
+++ b/src/test/java/tests/BasicTest.java
@@ -1,38 +1,39 @@
 import java.io.File;
 import java.util.List;
-
 import org.checkerframework.framework.test.CheckerFrameworkPerDirectoryTest;
 import org.junit.runners.Parameterized.Parameters;
 
 /**
  * Test runner that uses the Checker Framework's tooling.
  *
- * <p>The test data is located in the "tests/basic" folder (by Checker Framework convention). If this test fails,
- * that means that one or more of the Java files in that directory, when run through the typechecker, did
- * not produce the expected results.
+ * <p>The test data is located in the "tests/basic" folder (by Checker Framework convention). If
+ * this test fails, that means that one or more of the Java files in that directory, when run
+ * through the typechecker, did not produce the expected results.
  *
- * <p>When looking at the tests in that folder, lines starting with "// :: error: " are expected errors. The test will
- * fail if they are not present. The rest of those lines are error keys, which are printed by the typechecker. So,
- * for example, "// :: error: argument.type.incompatible" means that an argument type on the following line should
- * be incompatible with a parameter type.
+ * <p>When looking at the tests in that folder, lines starting with "// :: error: " are expected
+ * errors. The test will fail if they are not present. The rest of those lines are error keys, which
+ * are printed by the typechecker. So, for example, "// :: error: argument.type.incompatible" means
+ * that an argument type on the following line should be incompatible with a parameter type.
  *
- * <p>To add a new test case, create a Java file in that directory. Use the "// :: error: " syntax to add any expected
- * warnings. All files ending in .java in that directory will automatically be run by this test runner.
+ * <p>To add a new test case, create a Java file in that directory. Use the "// :: error: " syntax
+ * to add any expected warnings. All files ending in .java in that directory will automatically be
+ * run by this test runner.
  *
- * <p>This test runner depends on the Checker Framework's testing library, which is found in the Maven artifact
- * org.checkerframework:testlib.
+ * <p>This test runner depends on the Checker Framework's testing library, which is found in the
+ * Maven artifact org.checkerframework:testlib.
  */
 public class BasicTest extends CheckerFrameworkPerDirectoryTest {
-    public BasicTest(List<File> testFiles) {
-        super(testFiles,
-                org.checkerframework.checker.builder.TypesafeBuilderChecker.class,
-                "basic",
-                "-Anomsgtext",
-                "-nowarn");
-    }
+  public BasicTest(List<File> testFiles) {
+    super(
+        testFiles,
+        org.checkerframework.checker.builder.TypesafeBuilderChecker.class,
+        "basic",
+        "-Anomsgtext",
+        "-nowarn");
+  }
 
-    @Parameters
-    public static String[] getTestDirs() {
-        return new String[] {"basic"};
-    }
+  @Parameters
+  public static String[] getTestDirs() {
+    return new String[] {"basic"};
+  }
 }

--- a/src/test/java/tests/EC2Test.java
+++ b/src/test/java/tests/EC2Test.java
@@ -1,23 +1,23 @@
 package tests;
 
+import java.io.File;
+import java.util.List;
 import org.checkerframework.framework.test.CheckerFrameworkPerDirectoryTest;
 import org.junit.runners.Parameterized;
 
-import java.io.File;
-import java.util.List;
-
 public class EC2Test extends CheckerFrameworkPerDirectoryTest {
-    public EC2Test(List<File> testFiles) {
-        super(testFiles,
-                org.checkerframework.checker.builder.TypesafeBuilderChecker.class,
-                "cve",
-                "-Anomsgtext",
-                "-Astubs=stubs",
-                "-nowarn");
-    }
+  public EC2Test(List<File> testFiles) {
+    super(
+        testFiles,
+        org.checkerframework.checker.builder.TypesafeBuilderChecker.class,
+        "cve",
+        "-Anomsgtext",
+        "-Astubs=stubs",
+        "-nowarn");
+  }
 
-    @Parameterized.Parameters
-    public static String[] getTestDirs() {
-        return new String[] {"cve"};
-    }
+  @Parameterized.Parameters
+  public static String[] getTestDirs() {
+    return new String[] {"cve"};
+  }
 }


### PR DESCRIPTION
Via the [spotless](https://github.com/diffplug/spotless/tree/master/plugin-gradle#applying-to-java-source-google-java-format) plugin, using Google's Java format (which I am a fan of, and which is used by the Checker Framework).

I am merging this change without approval, assuming that it builds on Travis, because it is non-functional.