### PR TITLE
Fix some false positives in the CVE examples

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,8 @@ publishing {
 
 // run google java format
 spotless {
+    // uncomment this line to temporarily disable spotless (i.e. when debugging)
+    // enforceCheck = false
     java {
         googleJavaFormat()
     }

--- a/stubs/DescribeImages.astub
+++ b/stubs/DescribeImages.astub
@@ -4,8 +4,8 @@ import org.checkerframework.checker.builder.qual.*;
 
 class AmazonEC2 {
     DescribeImagesResult describeImages(
-    // any combination of withX/setX has to be permitted if both a filter and an owner has been set or an imageId has been set
-    @CalledMethodsPredicate("((withFilters || setFilters) && (withOwners || setOwners)) || (withImageIds || setImageIds)")
+    // any combination of withX/setX has to be permitted if an owner has been set or an imageId has been set
+    @CalledMethodsPredicate("(withOwners || setOwners) || (withImageIds || setImageIds)")
     DescribeImagesRequest request);
 }
 

--- a/stubs/DescribeImages.astub
+++ b/stubs/DescribeImages.astub
@@ -21,4 +21,13 @@ class DescribeImagesRequest {
 
     @ReturnsReceiver
     DescribeImagesRequest withImageIds(String... i);
+
+    @ReturnsReceiver
+    DescribeImagesRequest withFilters(Collection<Filter> f);
+
+    @ReturnsReceiver
+    DescribeImagesRequest withOwners(Collection<String> o);
+
+    @ReturnsReceiver
+    DescribeImagesRequest withImageIds(Collection<String> i);
 }

--- a/tests/cve/OnlyOwnersFalsePositive.java
+++ b/tests/cve/OnlyOwnersFalsePositive.java
@@ -1,0 +1,15 @@
+import com.amazonaws.services.ec2.model.DescribeImagesRequest;
+import com.amazonaws.services.ec2.model.DescribeImagesResult;
+import com.amazonaws.services.ec2.AmazonEC2;
+
+import java.util.Collections;
+
+// Tests that just setting with/setOwners is permitted, since there are legitimate reasons to do that.
+// Originally, we required with/setFilters && with/setOwners.
+class OnlyOwnersFalsePositive {
+    void test(AmazonEC2 ec2Client) {
+        DescribeImagesRequest describeImagesRequest = new DescribeImagesRequest();
+        describeImagesRequest.setOwners(Collections.singleton("self"));
+        DescribeImagesResult describeImagesResult = ec2Client.describeImages(describeImagesRequest);
+    }
+}

--- a/tests/cve/RequestCreatedInCall.java
+++ b/tests/cve/RequestCreatedInCall.java
@@ -1,0 +1,16 @@
+import com.amazonaws.services.ec2.model.DescribeImagesRequest;
+import com.amazonaws.services.ec2.model.DescribeImagesResult;
+import com.amazonaws.services.ec2.model.Filter;
+import com.amazonaws.services.ec2.AmazonEC2;
+
+import java.util.*;
+
+// A test to ensure that requests that are created in the call to describeImages work correctly.
+class RequestCreatedInCall {
+    void test(AmazonEC2 ec2) {
+        List<Filter> filters = new ArrayList<>();
+        filters.add(new Filter().withName("foo").withValues("bar"));
+        DescribeImagesResult describeImagesResult =
+                ec2.describeImages(new DescribeImagesRequest().withOwners("martin").withFilters(filters));
+    }
+}

--- a/tests/cve/SimpleFalsePositive.java
+++ b/tests/cve/SimpleFalsePositive.java
@@ -1,0 +1,18 @@
+import com.amazonaws.services.ec2.model.DescribeImagesRequest;
+import com.amazonaws.services.ec2.model.DescribeImagesResult;
+import com.amazonaws.services.ec2.model.Filter;
+import com.amazonaws.services.ec2.AmazonEC2;
+
+import java.util.*;
+
+// A simple (potential) false positive case with mutliple filters.
+class SimpleFalsePositive {
+    void test(AmazonEC2 ec2client, String namePrefix) {
+        DescribeImagesRequest request = new DescribeImagesRequest()
+                .withOwners("martin")
+                .withFilters(Arrays.asList(
+                        new Filter("platform", Arrays.asList("windows")),
+                        new Filter("name", Arrays.asList(String.format("%s*", namePrefix)))));
+        DescribeImagesResult result = ec2Client.describeImages(request);
+    }
+}

--- a/tests/cve/SimpleFalsePositive.java
+++ b/tests/cve/SimpleFalsePositive.java
@@ -7,7 +7,7 @@ import java.util.*;
 
 // A simple (potential) false positive case with mutliple filters.
 class SimpleFalsePositive {
-    void test(AmazonEC2 ec2client, String namePrefix) {
+    void test(AmazonEC2 ec2Client, String namePrefix) {
         DescribeImagesRequest request = new DescribeImagesRequest()
                 .withOwners("martin")
                 .withFilters(Arrays.asList(


### PR DESCRIPTION
Added some new test cases that are examples of false positives encountered while using the CVE stub to hunt for mis-uses of AWS APIs. All were attributable to the stub file being overly restrictive, which it was in two distinct ways:
* the stub file *required* programmers to call `withFilters` if they called `withOwners`. Some people might legitimately want to find all the AMIs belonging to an owner, so I eased that restriction.
* the stub file only included `@ReturnsReceiver` annotations on the versions of the `withX` methods that take a varargs array, and not the versions that take a collection, so calls to those versions of the methods were causing information to be lost.