### PR TITLE
Implement @CalledMethods insertion for AutoValue Builders

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     testCompile 'com.amazonaws:aws-java-sdk-ec2'
 
     // For AutoValue Builders
+    implementation 'com.google.auto.value:auto-value-annotations:1.6.5'
     testCompile 'com.google.auto.value:auto-value-annotations:1.6.5'
     testCompile 'com.google.auto.value:auto-value:1.6.5'
 }

--- a/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderAnnotatedTypeFactory.java
+++ b/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderAnnotatedTypeFactory.java
@@ -1,9 +1,19 @@
 package org.checkerframework.checker.builder;
 
 import com.google.auto.value.AutoValue;
-import com.sun.source.tree.*;
+import com.sun.source.tree.AnnotationTree;
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.Tree;
 import java.lang.annotation.Annotation;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
@@ -173,10 +183,11 @@ public class TypesafeBuilderAnnotatedTypeFactory extends BaseAnnotatedTypeFactor
     }
 
     /**
-     * computes the required properties of an @AutoValue class
+     * computes the required properties of an @AutoValue class, i.e., those methods returning some non-void,
+     * non-@Nullable type
      *
-     * @param autoValueClass
-     * @return
+     * @param autoValueClass the @AutoValue class
+     * @return a list of required property names
      */
     private List<String> getRequiredProperties(ClassTree autoValueClass) {
       List<String> requiredPropertyNames = new ArrayList<>();

--- a/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderAnnotatedTypeFactory.java
+++ b/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderAnnotatedTypeFactory.java
@@ -183,8 +183,8 @@ public class TypesafeBuilderAnnotatedTypeFactory extends BaseAnnotatedTypeFactor
     }
 
     /**
-     * computes the required properties of an @AutoValue class, i.e., those methods returning some non-void,
-     * non-@Nullable type
+     * computes the required properties of an @AutoValue class, i.e., those methods returning some
+     * non-void, non-@Nullable type
      *
      * @param autoValueClass the @AutoValue class
      * @return a list of required property names

--- a/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderAnnotatedTypeFactory.java
+++ b/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderAnnotatedTypeFactory.java
@@ -4,7 +4,6 @@ import com.google.auto.value.AutoValue;
 import com.sun.source.tree.*;
 import java.lang.annotation.Annotation;
 import java.util.*;
-import java.util.stream.Collectors;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
@@ -214,11 +213,11 @@ public class TypesafeBuilderAnnotatedTypeFactory extends BaseAnnotatedTypeFactor
      * @return the @CalledMethods annotation
      */
     public AnnotationMirror createCalledMethodsForProperties(final List<String> propertyNames) {
-      List<String> calledMethodNames =
+      String[] calledMethodNames =
           propertyNames.stream()
               .map((prop) -> "set" + prop.substring(0, 1).toUpperCase() + prop.substring(1))
-              .collect(Collectors.toList());
-      return createCalledMethods(calledMethodNames.toArray(new String[0]));
+              .toArray(String[]::new);
+      return createCalledMethods(calledMethodNames);
     }
   }
   /**

--- a/src/test/java/tests/AutoValueTest.java
+++ b/src/test/java/tests/AutoValueTest.java
@@ -26,7 +26,6 @@ public class AutoValueTest extends CheckerFrameworkPerDirectoryTest {
         org.checkerframework.checker.builder.TypesafeBuilderChecker.class,
         "autovalue",
         "-Anomsgtext",
-        "-AskipDefs=AutoValue_*",
         "-nowarn");
   }
 

--- a/tests/autovalue/Animal.java
+++ b/tests/autovalue/Animal.java
@@ -1,6 +1,6 @@
 import com.google.auto.value.AutoValue;
 import org.checkerframework.checker.builder.qual.*;
-import org.checkerframework.checker.returnsrcvr.qual.*;
+import org.checkerframework.checker.nullness.qual.*;
 
 /**
  * Adapted from the standard AutoValue example code:
@@ -10,6 +10,8 @@ import org.checkerframework.checker.returnsrcvr.qual.*;
 abstract class Animal {
   abstract String name();
 
+  abstract @Nullable String habitat();
+
   abstract int numberOfLegs();
 
   static Builder builder() {
@@ -18,11 +20,14 @@ abstract class Animal {
 
   @AutoValue.Builder
   abstract static class Builder {
-    abstract @This Builder setName(String value);
 
-    abstract @This Builder setNumberOfLegs(int value);
+    abstract Builder setName(String value);
 
-    abstract Animal build(@CalledMethods({"setName", "setNumberOfLegs"}) Builder this);
+    abstract Builder setNumberOfLegs(int value);
+
+    abstract Builder setHabitat(String value);
+
+    abstract Animal build();
   }
 
   public static void buildSomethingWrong() {
@@ -36,6 +41,14 @@ abstract class Animal {
     Builder b = builder();
     b.setName("Frank");
     b.setNumberOfLegs(4);
+    b.build();
+  }
+
+  public static void buildSomethingRightIncludeOptional() {
+    Builder b = builder();
+    b.setName("Frank");
+    b.setNumberOfLegs(4);
+    b.setHabitat("jungle");
     b.build();
   }
 


### PR DESCRIPTION
Support for inserting `@This` annotations for AutoValue Builders was added to the returns receiver checker in msridhar/returnsrecv-checker#1.  Building on that, this PR implements `@CalledMethods` insertion for AutoValue Builders.  With this change, the checker is able to check AutoValue Builder usage for correctness with no manual annotations required; see updates to the `Animal.java` test case.