### PR TITLE
Add manifest file for processor auto-discovery

### DIFF
--- a/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+org.checkerframework.checker.builder.TypesafeBuilderChecker


### PR DESCRIPTION
This will allow us to run the checker without adding a `-processor` flag, by just adding the jar to the processor path, leveraging processor auto-discovery.  This is important for running on projects that already use processor auto-discovery.