### PR TITLE
Fixes for AutoValue support

### DIFF
--- a/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderAnnotatedTypeFactory.java
+++ b/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderAnnotatedTypeFactory.java
@@ -480,9 +480,11 @@ public class TypesafeBuilderAnnotatedTypeFactory extends BaseAnnotatedTypeFactor
   private static String autoValuePropToBuilderSetterName(
       String prop, Set<String> allBuilderMethodNames) {
     // property name may be prefixed JavaBean style with 'get' or 'is'; strip that part if present
-    if (prop.startsWith("get") && Character.isUpperCase(prop.charAt(3))) {
+    if (prop.startsWith("get") && prop.length() > 3 && Character.isUpperCase(prop.charAt(3))) {
       prop = Introspector.decapitalize(prop.substring(3));
-    } else if (prop.startsWith("is") && Character.isUpperCase(prop.charAt(2))) {
+    } else if (prop.startsWith("is")
+        && prop.length() > 2
+        && Character.isUpperCase(prop.charAt(2))) {
       prop = Introspector.decapitalize(prop.substring(2));
     }
     // setter name may be the property name itself, or prefixed by 'set'

--- a/tests/autovalue/AnimalNoSet.java
+++ b/tests/autovalue/AnimalNoSet.java
@@ -1,0 +1,67 @@
+import com.google.auto.value.AutoValue;
+import org.checkerframework.checker.builder.qual.*;
+import org.checkerframework.checker.nullness.qual.*;
+
+/**
+ * Adapted from the standard AutoValue example code:
+ * https://github.com/google/auto/blob/master/value/userguide/builders.md
+ */
+@AutoValue
+abstract class AnimalNoSet {
+  abstract String name();
+
+  abstract @Nullable String habitat();
+
+  abstract int numberOfLegs();
+
+  public String getStr() {
+    return "str";
+  }
+
+  static Builder builder() {
+    return new AutoValue_AnimalNoSet.Builder();
+  }
+
+  @AutoValue.Builder
+  abstract static class Builder {
+
+    abstract Builder name(String value);
+
+    abstract Builder numberOfLegs(int value);
+
+    abstract Builder habitat(String value);
+
+    abstract AnimalNoSet build();
+  }
+
+  public static void buildSomethingWrong() {
+    Builder b = builder();
+    b.name("Frank");
+    // :: error: method.invocation.invalid
+    b.build();
+  }
+
+  public static void buildSomethingRight() {
+    Builder b = builder();
+    b.name("Frank");
+    b.numberOfLegs(4);
+    b.build();
+  }
+
+  public static void buildSomethingRightIncludeOptional() {
+    Builder b = builder();
+    b.name("Frank");
+    b.numberOfLegs(4);
+    b.habitat("jungle");
+    b.build();
+  }
+
+  public static void buildSomethingWrongFluent() {
+    // :: error: method.invocation.invalid
+    builder().name("Frank").build();
+  }
+
+  public static void buildSomethingRightFluent() {
+    builder().name("Jim").numberOfLegs(7).build();
+  }
+}

--- a/tests/autovalue/GetAndIs.java
+++ b/tests/autovalue/GetAndIs.java
@@ -1,0 +1,47 @@
+import com.google.auto.value.AutoValue;
+import org.checkerframework.checker.builder.qual.*;
+import org.checkerframework.checker.nullness.qual.*;
+
+@AutoValue
+abstract class GetAndIs {
+  abstract String get();
+
+  abstract boolean is();
+
+  static Builder builder() {
+    return new AutoValue_GetAndIs.Builder();
+  }
+
+  @AutoValue.Builder
+  abstract static class Builder {
+
+    abstract Builder setGet(String value);
+
+    abstract Builder setIs(boolean value);
+
+    abstract GetAndIs build();
+  }
+
+  public static void buildSomethingWrong() {
+    Builder b = builder();
+    b.setGet("Frank");
+    // :: error: method.invocation.invalid
+    b.build();
+  }
+
+  public static void buildSomethingRight() {
+    Builder b = builder();
+    b.setGet("Frank");
+    b.setIs(false);
+    b.build();
+  }
+
+  public static void buildSomethingWrongFluent() {
+    // :: error: method.invocation.invalid
+    builder().setGet("Frank").build();
+  }
+
+  public static void buildSomethingRightFluent() {
+    builder().setGet("Jim").setIs(true).build();
+  }
+}

--- a/tests/autovalue/GetAnimal.java
+++ b/tests/autovalue/GetAnimal.java
@@ -7,19 +7,17 @@ import org.checkerframework.checker.nullness.qual.*;
  * https://github.com/google/auto/blob/master/value/userguide/builders.md
  */
 @AutoValue
-abstract class Animal {
-  abstract String name();
+abstract class GetAnimal {
+  abstract String getName();
 
-  abstract @Nullable String habitat();
+  abstract @Nullable String getHabitat();
 
-  abstract int numberOfLegs();
+  abstract int getNumberOfLegs();
 
-  public String getStr() {
-    return "str";
-  }
+  abstract boolean isHasArms();
 
   static Builder builder() {
-    return new AutoValue_Animal.Builder();
+    return new AutoValue_GetAnimal.Builder();
   }
 
   @AutoValue.Builder
@@ -31,7 +29,9 @@ abstract class Animal {
 
     abstract Builder setHabitat(String value);
 
-    abstract Animal build();
+    abstract Builder setHasArms(boolean b);
+
+    abstract GetAnimal build();
   }
 
   public static void buildSomethingWrong() {
@@ -45,6 +45,7 @@ abstract class Animal {
     Builder b = builder();
     b.setName("Frank");
     b.setNumberOfLegs(4);
+    b.setHasArms(true);
     b.build();
   }
 
@@ -53,6 +54,7 @@ abstract class Animal {
     b.setName("Frank");
     b.setNumberOfLegs(4);
     b.setHabitat("jungle");
+    b.setHasArms(true);
     b.build();
   }
 
@@ -62,6 +64,6 @@ abstract class Animal {
   }
 
   public static void buildSomethingRightFluent() {
-    builder().setName("Jim").setNumberOfLegs(7).build();
+    builder().setName("Jim").setNumberOfLegs(7).setHasArms(false).build();
   }
 }


### PR DESCRIPTION
1. Don't treat non-`abstract` methods as corresponding to required properties
2. Handle more sophisticated mappings between AutoValue method names and the corresponding Builder method names