### PR TITLE
Handle AutoValue toBuilder method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ build
 # Ignore IntelliJ and emacs files
 .idea
 *~
+
+# Ignore the out directory created when running tests
+out

--- a/tests/autovalue/Animal.java
+++ b/tests/autovalue/Animal.java
@@ -18,6 +18,8 @@ abstract class Animal {
     return "str";
   }
 
+  public abstract Builder toBuilder();
+
   static Builder builder() {
     return new AutoValue_Animal.Builder();
   }
@@ -63,5 +65,10 @@ abstract class Animal {
 
   public static void buildSomethingRightFluent() {
     builder().setName("Jim").setNumberOfLegs(7).build();
+  }
+
+  public static void buildWithToBuilder() {
+    Animal a1 = builder().setName("Jim").setNumberOfLegs(7).build();
+    a1.toBuilder().build();
   }
 }


### PR DESCRIPTION
Feature documented here:

https://github.com/google/auto/blob/master/value/userguide/builders-howto.md#to_builder

We handle as follows:
* Don't treat `toBuilder` as a regular property requiring a setter in the `Builder`
* Inject an annotation on the returned `Builder` from `toBuilder`, indicating that all required properties are already set.
