### PR TITLE
Handle weird cases where 'is' and 'get' are part of property name

### DIFF
--- a/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderAnnotatedTypeFactory.java
+++ b/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderAnnotatedTypeFactory.java
@@ -515,17 +515,20 @@ public class TypesafeBuilderAnnotatedTypeFactory extends BaseAnnotatedTypeFactor
         && Character.isUpperCase(prop.charAt(2))) {
       prop = Introspector.decapitalize(prop.substring(2));
     }
-    // setter name may be the property name itself, or prefixed by 'set'
-    if (allBuilderMethodNames.contains(prop)) {
-      return prop;
-    } else {
-      String setterName = "set" + prop.substring(0, 1).toUpperCase() + prop.substring(1);
+    // setter name may be the property name itself, or prefixed by 'set' or 'is' or even 'get'
+    ImmutableSet<String> setterNamesToTry =
+        ImmutableSet.of(
+            prop, "set" + capitalize(prop), "is" + capitalize(prop), "get" + capitalize(prop));
+    for (String setterName : setterNamesToTry) {
       if (allBuilderMethodNames.contains(setterName)) {
         return setterName;
-      } else {
-        throw new RuntimeException("could not find Builder setter name for property " + prop);
       }
     }
+    throw new RuntimeException("could not find Builder setter name for property " + prop);
+  }
+
+  private static String capitalize(String prop) {
+    return prop.substring(0, 1).toUpperCase() + prop.substring(1);
   }
 
   /**

--- a/tests/autovalue/IsPreserved.java
+++ b/tests/autovalue/IsPreserved.java
@@ -1,0 +1,41 @@
+import com.google.auto.value.AutoValue;
+import org.checkerframework.checker.builder.qual.*;
+import org.checkerframework.checker.nullness.qual.*;
+
+@AutoValue
+abstract class IsPreserved {
+
+  abstract String name();
+
+  abstract String getAddress();
+
+  abstract boolean isPresent();
+
+  static Builder builder() {
+    return new AutoValue_IsPreserved.Builder();
+  }
+
+  @AutoValue.Builder
+  abstract static class Builder {
+
+    abstract Builder name(String val);
+
+    abstract Builder getAddress(String val);
+
+    abstract Builder isPresent(boolean value);
+
+    abstract IsPreserved build();
+  }
+
+  public static void buildSomethingRight() {
+    Builder b = builder();
+    b.name("Frank");
+    b.getAddress("something");
+    b.isPresent(true);
+    b.build();
+  }
+
+  public static void buildSomethingRightFluent() {
+    builder().name("Bill").getAddress("something").isPresent(false).build();
+  }
+}


### PR DESCRIPTION
In some cases AutoValue decides to not strip 'is' and 'get' from property names, so they become part of the name.  Rather than figuring out the exact logic behind this scenario, we just try a few possibilities for setter names in the Builder.