### PR TITLE
Handle generated code for AutoValue toBuilder

### DIFF
--- a/tests/autovalue/Animal.java
+++ b/tests/autovalue/Animal.java
@@ -18,8 +18,7 @@ abstract class Animal {
     return "str";
   }
 
-  // TEMPORARY will fix in follow-up PR
-  //public abstract Builder toBuilder();
+  public abstract Builder toBuilder();
 
   static Builder builder() {
     return new AutoValue_Animal.Builder();
@@ -68,9 +67,8 @@ abstract class Animal {
     builder().setName("Jim").setNumberOfLegs(7).build();
   }
 
-  // TEMPORARY will fix in follow-up PR
-//  public static void buildWithToBuilder() {
-//    Animal a1 = builder().setName("Jim").setNumberOfLegs(7).build();
-//    a1.toBuilder().build();
-//  }
+  public static void buildWithToBuilder() {
+    Animal a1 = builder().setName("Jim").setNumberOfLegs(7).build();
+    a1.toBuilder().build();
+  }
 }


### PR DESCRIPTION
The generated code corresponding to `AutoValue.toBuilder` now type checks.  We had to inject a `@CalledMethods` annotation with all required setters in the following places:

1. On the return of the generated `toBuilder()` method
2. On the call of the `Builder` constructor within the generated `toBuilder()` method

This change required pulling several methods out of the type annotator so they could also be used by the tree annotator.  I handled the constructor call in the tree annotator since I got weird new errors when trying to annotate the constructor itself in the type annotator.