### PR TITLE
Add separate qual artifact

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,14 +63,36 @@ tasks.withType(JavaCompile).all {
     options.compilerArgs.add("-Xlint:all")
 }
 
+def tsbcVersion = '0.1-SNAPSHOT'
+
+task qualJar(type: Jar) {
+    baseName 'typesafe-builder-qual'
+    from (sourceSets.main.output) {
+        include "**/qual/**"
+    }
+}
+
 publishing {
     publications {
-        maven(MavenPublication) {
+        checker(MavenPublication) {
             groupId = 'org.checkerframework'
             artifactId = 'typesafe-builder'
-            version = '0.1-SNAPSHOT'
+            version = "${tsbcVersion}"
 
             from components.java
+        }
+
+        qual(MavenPublication) {
+            groupId = 'org.checkerframework'
+            artifactId = 'typesafe-builder-qual'
+            version = "${tsbcVersion}"
+            artifact qualJar
+            pom.withXml {
+                def depNode = asNode().appendNode("dependencies").appendNode("dependency")
+                depNode.appendNode("groupId", "org.checkerframework")
+                depNode.appendNode("artifactId", "returnsrcvr-qual")
+                depNode.appendNode("version", "0.1-SNAPSHOT")
+            }
         }
     }
 }


### PR DESCRIPTION
This adds a separate artifact containing only the type annotations defined by the checker, following the same design style as the `checker.jar` vs `checker-qual.jar` difference in the main Checker Framework.

A separate artifact is needed because the annotations need to be on the actual classpath when compiling the program, but the checker (and its heavy-weight dependency on the Checker Framework) does not.

This pull request depends on [#11](https://github.com/msridhar/returnsrecv-checker/pull/11) in the Returns Receiver Checker, because it automatically adds the new qual artifact of that checker as a dependency to this qual artifact - which means that a user who wants to use this checker only needs to take the one dependency.