### PR TITLE
Check that AutoValue toBuilder() method is abstract

### DIFF
--- a/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderAnnotatedTypeFactory.java
+++ b/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderAnnotatedTypeFactory.java
@@ -217,7 +217,8 @@ public class TypesafeBuilderAnnotatedTypeFactory extends BaseAnnotatedTypeFactor
       TypeMirror superclass = enclosingElement.getSuperclass();
 
       if ("toBuilder".equals(methodName)) {
-        if (hasAnnotation(enclosingElement, AutoValue.class)) {
+        if (hasAnnotation(enclosingElement, AutoValue.class)
+            && element.getModifiers().contains(Modifier.ABSTRACT)) {
           handleAutoValueToBuilder(t, enclosingElement);
           return super.visitExecutable(t, p);
         }

--- a/tests/autovalue/NonAVBuilder.java
+++ b/tests/autovalue/NonAVBuilder.java
@@ -1,0 +1,20 @@
+import com.google.auto.value.AutoValue;
+import org.checkerframework.checker.builder.qual.*;
+import org.checkerframework.checker.nullness.qual.*;
+
+@AutoValue
+abstract class NonAVBuilder {
+  abstract String name();
+
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  // NOT an AutoValue builder
+  static final class Builder {
+
+    Builder(NonAVBuilder b) {}
+
+  }
+
+}


### PR DESCRIPTION
Previously, we would try to handle non-abstract `toBuilder` methods that were unrelated to AutoValue, causing a crash.