### PR TITLE
Fix handling of Guava Immutable types

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     implementation 'com.google.auto.value:auto-value-annotations:1.6.5'
     testCompile 'com.google.auto.value:auto-value-annotations:1.6.5'
     testCompile 'com.google.auto.value:auto-value:1.6.5'
+    testCompile 'com.google.guava:guava:28.0-jre'
 
     // For Lombok Builders
     implementation 'org.projectlombok:lombok:1.18.8'

--- a/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderAnnotatedTypeFactory.java
+++ b/src/main/java/org/checkerframework/checker/builder/TypesafeBuilderAnnotatedTypeFactory.java
@@ -252,11 +252,12 @@ public class TypesafeBuilderAnnotatedTypeFactory extends BaseAnnotatedTypeFactor
 
         if ("build".equals(methodName)) {
           // determine the required properties and add a corresponding @CalledMethods annotation
+          Set<String> allBuilderMethodNames = getAllMethodNames(enclosingElement);
           List<String> requiredProperties =
-              getRequiredProperties(nextEnclosingElement, builderKind);
+              getRequiredProperties(nextEnclosingElement, allBuilderMethodNames, builderKind);
           AnnotationMirror newCalledMethodsAnno =
               createCalledMethodsForProperties(
-                  requiredProperties, getAllMethodNames(enclosingElement), builderKind);
+                  requiredProperties, allBuilderMethodNames, builderKind);
           t.getReceiverType().addAnnotation(newCalledMethodsAnno);
         }
       }
@@ -296,11 +297,11 @@ public class TypesafeBuilderAnnotatedTypeFactory extends BaseAnnotatedTypeFactor
   private void handleAutoValueToBuilderType(
       AnnotatedTypeMirror type, Element autoValueClassElement) {
     Element builderElement = TypesUtils.getTypeElement(type.getUnderlyingType());
+    Set<String> allBuilderMethodNames = getAllMethodNames(builderElement);
     List<String> requiredProperties =
-        getRequiredProperties(autoValueClassElement, BuilderKind.AUTO_VALUE);
+        getRequiredProperties(autoValueClassElement, allBuilderMethodNames, BuilderKind.AUTO_VALUE);
     AnnotationMirror calledMethodsAnno =
-        createCalledMethodsForAutoValueProperties(
-            requiredProperties, getAllMethodNames(builderElement));
+        createCalledMethodsForAutoValueProperties(requiredProperties, allBuilderMethodNames);
     type.replaceAnnotation(calledMethodsAnno);
   }
 
@@ -308,14 +309,17 @@ public class TypesafeBuilderAnnotatedTypeFactory extends BaseAnnotatedTypeFactor
    * computes the required properties of a builder class
    *
    * @param builderElement the class whose builder is to be checked
+   * @param allBuilderMethodNames
    * @param builderKind the framework by which the builder will be generated
    * @return a list of required property names
    */
   private List<String> getRequiredProperties(
-      final Element builderElement, final BuilderKind builderKind) {
+      final Element builderElement,
+      Set<String> allBuilderMethodNames,
+      final BuilderKind builderKind) {
     switch (builderKind) {
       case AUTO_VALUE:
-        return getAutoValueRequiredProperties(builderElement);
+        return getAutoValueRequiredProperties(builderElement, allBuilderMethodNames);
       case LOMBOK:
         return getLombokRequiredProperties(builderElement);
       default:
@@ -358,9 +362,11 @@ public class TypesafeBuilderAnnotatedTypeFactory extends BaseAnnotatedTypeFactor
    * non-void, non-@Nullable type
    *
    * @param autoValueClassElement the @AutoValue class
+   * @param allBuilderMethodNames
    * @return a list of required property names
    */
-  private List<String> getAutoValueRequiredProperties(final Element autoValueClassElement) {
+  private List<String> getAutoValueRequiredProperties(
+      final Element autoValueClassElement, Set<String> allBuilderMethodNames) {
     List<String> requiredPropertyNames = new ArrayList<>();
     for (Element member : autoValueClassElement.getEnclosedElements()) {
       if (member.getKind().equals(ElementKind.METHOD)) {
@@ -368,8 +374,8 @@ public class TypesafeBuilderAnnotatedTypeFactory extends BaseAnnotatedTypeFactor
         Set<Modifier> modifiers = member.getModifiers();
         if (!modifiers.contains(Modifier.STATIC) && modifiers.contains(Modifier.ABSTRACT)) {
           String name = member.getSimpleName().toString();
-          if (!IGNORED_METHOD_NAMES.contains(name)
-              && !((ExecutableElement) member).getReturnType().toString().equals("void")) {
+          String returnType = ((ExecutableElement) member).getReturnType().toString();
+          if (!IGNORED_METHOD_NAMES.contains(name) && !returnType.equals("void")) {
             // shouldn't have a nullable return
             boolean hasNullable =
                 Stream.concat(
@@ -377,9 +383,16 @@ public class TypesafeBuilderAnnotatedTypeFactory extends BaseAnnotatedTypeFactor
                         ((ExecutableElement) member)
                             .getReturnType().getAnnotationMirrors().stream())
                     .anyMatch(anm -> AnnotationUtils.annotationName(anm).endsWith(".Nullable"));
-            if (!hasNullable) {
-              requiredPropertyNames.add(name);
+            if (hasNullable) {
+              continue;
             }
+            // if return type of foo() is a Guava Immutable type, not required if there is a builder
+            // method fooBuilder()
+            if (returnType.startsWith("com.google.common.collect.Immutable")
+                && allBuilderMethodNames.contains(name + "Builder")) {
+              continue;
+            }
+            requiredPropertyNames.add(name);
           }
         }
       }

--- a/tests/autovalue/GuavaImmutable.java
+++ b/tests/autovalue/GuavaImmutable.java
@@ -1,0 +1,34 @@
+import com.google.auto.value.AutoValue;
+import org.checkerframework.checker.builder.qual.*;
+import org.checkerframework.checker.nullness.qual.*;
+
+import com.google.common.collect.ImmutableList;
+
+@AutoValue
+abstract class GuavaImmutable {
+
+  public abstract ImmutableList<String> names();
+
+  static Builder builder() {
+    return new AutoValue_GuavaImmutable.Builder();
+  }
+
+  @AutoValue.Builder
+  abstract static class Builder {
+
+    abstract Builder names(ImmutableList<String> value);
+
+    abstract GuavaImmutable build();
+
+  }
+
+  public static void buildSomethingWrong() {
+    // :: error: method.invocation.invalid
+    builder().build();
+  }
+
+  public static void buildSomethingRight() {
+    builder().names(ImmutableList.of()).build();
+  }
+
+}

--- a/tests/autovalue/GuavaImmutablePropBuilder.java
+++ b/tests/autovalue/GuavaImmutablePropBuilder.java
@@ -1,0 +1,29 @@
+import com.google.auto.value.AutoValue;
+import org.checkerframework.checker.builder.qual.*;
+import org.checkerframework.checker.nullness.qual.*;
+
+import com.google.common.collect.ImmutableList;
+
+@AutoValue
+abstract class GuavaImmutablePropBuilder {
+
+  public abstract ImmutableList<String> names();
+
+  static Builder builder() {
+    return new AutoValue_GuavaImmutablePropBuilder.Builder();
+  }
+
+  @AutoValue.Builder
+  abstract static class Builder {
+
+    abstract ImmutableList.Builder<String> namesBuilder();
+
+    abstract GuavaImmutablePropBuilder build();
+
+  }
+
+  public static void buildSomething() {
+    // don't need to explicitly set the names
+    builder().build();
+  }
+}


### PR DESCRIPTION
AutoValue has special handling of properties with a Guava Immutable type.  For such a property `foo`, if the AutoValue Builder has a method `fooBuilder()`, then the Builder automatically populates the property with an empty collection if `fooBuilder()` is never called.  So in such cases, don't treat `foo` as a required property.